### PR TITLE
Change module names

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fpp-sle"
-version = "0.0.7"
+version = "0.0.8"
 description = "Implements FPP and SLE algorithms"
 authors = ["engeir <eirroleng@gmail.com>"]
 license = "GPL-3.0-or-later"

--- a/src/fpp_sle/__init__.py
+++ b/src/fpp_sle/__init__.py
@@ -1,2 +1,2 @@
 """Filtered Poisson process and stochastic logistic equations library."""
-__version__ = "0.0.7"
+__version__ = "0.0.8"

--- a/src/fpp_sle/fpp/__init__.py
+++ b/src/fpp_sle/fpp/__init__.py
@@ -1,3 +1,3 @@
 """Module implementing point processes and properties related to them."""
 from fpp_sle.fpp import get_arrival_times  # noqa: F401
-from fpp_sle.fpp.implementations import *  # noqa: F401, F403
+from fpp_sle.fpp.forcing_generators import *  # noqa: F401, F403

--- a/src/fpp_sle/fpp/forcing_generators.py
+++ b/src/fpp_sle/fpp/forcing_generators.py
@@ -1,4 +1,4 @@
-"""Module implementing superposed pulses."""
+"""Implementation of superposed pulses variable rate forcing class."""
 
 from typing import Callable
 

--- a/src/fpp_sle/sde/__init__.py
+++ b/src/fpp_sle/sde/__init__.py
@@ -3,4 +3,4 @@
 Originally implemented in the abandoned project `uit_scripts`, in the `runge_kutta_SDE`
 module. Re-formatted with type hints and re-implemented in `fpp_sle` module.
 """
-from fpp_sle.sde.implementations import *  # noqa: F401, F403
+from fpp_sle.sde.runge_kutta_sde import *  # noqa: F401, F403

--- a/src/fpp_sle/sde/runge_kutta_sde.py
+++ b/src/fpp_sle/sde/runge_kutta_sde.py
@@ -1,7 +1,7 @@
-"""Module implementing different stochastic differential equations as numba jit functions.
+"""Implementation of different stochastic differential equations as numba jit functions.
 
 Originally implemented in the abandoned project `uit_scripts`, in the `runge_kutta_SDE`
-module. Re-formatted with type hints and re-implemented in `fpp_sle` module.
+module. Re-formatted with type hints and re-implemented in the `fpp_sle` package.
 """
 
 from typing import Callable, Optional


### PR DESCRIPTION
Two scripts were named `implementations.py`, which does not say much in itself.

None of the name changes affect the user side, though, since both scripts with all content were imported in `__init__.py` files.